### PR TITLE
Fix import of 'Markup'

### DIFF
--- a/src/flask_feather/extension.py
+++ b/src/flask_feather/extension.py
@@ -1,5 +1,5 @@
 from flask import current_app
-from jinja2 import Markup
+from MarkupSafe import Markup
 from xml.dom import minidom
 import io
 import os


### PR DESCRIPTION
It's now part of `MarkupSafe`, not `jinja2`